### PR TITLE
add 'rpm' package to the container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,8 @@ RUN apt-get update && \
         qemu-utils \
         rsync \
         software-properties-common \
-        unzip && \
+        unzip \
+        rpm && \
     apt-get autoremove -y && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Want to use RPM to query metadata about artifacts in our tests. Need that to intelligently parse things instead of going of filenames/paths.